### PR TITLE
Close #4, change game start condition to check state of the player list 

### DIFF
--- a/server.js
+++ b/server.js
@@ -169,8 +169,7 @@ io.on('connection', function (socket) {
 				currentPlayerIndex = null;
 				
 				// Turn off the timer
-				clearInterval(timerId);
-				timerId = null;
+				clearInterval(timerId);				
 				nextTurnChangeTimestamp = null;
 			
 			// Otherwise, if there are players left,
@@ -178,9 +177,9 @@ io.on('connection', function (socket) {
 			 	// If the disconnected user was the current player, restart timer and change the turn!
 			 	if (socket.id === currentPlayerId) {
 					console.log('\nCURRENT PLAYER disconnected! Restarting turn/timer.\n');
+					
 					// Turn off the timer
-					clearInterval(timerId);
-					timerId = null;
+					clearInterval(timerId);					
 					nextTurnChangeTimestamp = null;
 
 					// Re-initialize the turn (and timer), passing control to the next user

--- a/server.js
+++ b/server.js
@@ -121,10 +121,10 @@ io.on('connection', function (socket) {
 		if (editorCursorAndSelection != null) {
 			socket.emit('editorCursorChange', editorCursorAndSelection);
 		}
-
-		// Initialize the turn (and timer) with first connected user
-		// and create the initial GitHub gist on behlaf of the first user!
-		if (timerId == null) {
+		
+		// If there is 1 player logged in (the first player to join, who just triggered the "userLogin" event),
+		// START THE GAME!!!
+		if (playerList.length === 1) {
 			timerId = startTurnTimer(timerId, turnDuration, socket.id);
 			
 			// Notify the first user to create a new gist now!
@@ -318,7 +318,7 @@ function startTurnTimer(timerId, turnDuration, socketId) {
 	console.log( 'Next turn at: ' + new Date(nextTurnChangeTimestamp).toString().substring(16,25) );	
 
 	// Initialize the turn data using given user ID
-	changeTurn(socketId);		
+	changeTurn(socketId);
 
 	// Every time the timer goes off,
 	timerId = setInterval(() => {	  			  		


### PR DESCRIPTION
Closes #4. Now game start condition depends on length of player list (game starts when ***one*** player is logged in), and `timerId` no longer needs to be reset to `null`.