### PR TITLE
Close #16, strip out and refactor all the guts of the app!

### DIFF
--- a/public/local.js
+++ b/public/local.js
@@ -272,7 +272,7 @@ function handlePlayerJoined (playerData) {
 	gameState.players.push(playerData);
 
 	// Merge the two arrays, reording so current user is at the top (but removed from this list), without modifying the turn order
-	var clientIndex = getPlayerIndexById(socket.id, gameState,players);
+	var clientIndex = getPlayerIndexById(socket.id, gameState.players);
 	var playersTopSegment = gameState.players.slice(clientIndex);
 	var playersBottomSegment = gameState.players.slice(0, clientIndex);
 	var reorderedPlayers = playersTopSegment.concat(playersBottomSegment);

--- a/public/local.js
+++ b/public/local.js
@@ -185,28 +185,6 @@ function handleLocalEditorTextChange (event) {
 	}
 }
 
-// Function that prevents user from typing when it's not their turn
-function preventUserTyping (event) {
-	event.preventDefault();
-	//return false;
-};
-
-// Send user's new name to server and update UI
-function handleUserNameChange (event) {
-	//console.log('handleUserNameChange event! value: ');
-	//console.log('%c ' + myNameView.textContent, 'color: green; font-weight: bold;');
-	
-	// Update UI if user is the current or next player
-	if (getCurrentPlayer().id === socket.id) {
-		updateCurrentTurnView(myNameView.textContent);	
-	} else if (nextPlayerId === socket.id) {
-		updateNextTurnView(myNameView.textContent);	
-	}
-
-	// Send user's new name to server
-	socket.emit('userNameChange', myNameView.textContent);	
-}
-
 // Send cursor and selection data to server
 function handleLocalEditorCursorChange (event) {
 	// Cursor object:
@@ -489,7 +467,7 @@ function updateCurrentTurnView (playerName) {
 	currentTurnView.textContent = playerName;
 
 	// If user is the current player, highlight their name
-	if (socket.id === currentPlayerId) {
+	if (socket.id === getCurrentPlayer().id) {
 		currentTurnView.classList.add('highlightme');
 		currentTurnView.textContent = "It's your turn!";
 	} else {
@@ -503,7 +481,7 @@ function updateNextTurnView (playerName) {
 	nextTurnView.textContent = playerName;
 
 	// If user is the next player, highlight their name
-	if (socket.id === nextPlayerId) {
+	if (socket.id === getNextPlayer().id) {
 		nextTurnView.classList.add('highlightme');
 		nextTurnView.textContent = "You're up next!";
 	} else {

--- a/public/local.js
+++ b/public/local.js
@@ -243,6 +243,8 @@ function handleGameState (serverGameState) {
 	// If no Gist exists, create it!
 	if (gameState.currentGist == null)  {
 		createNewGist();
+	} else { // Otherwise, if a Gist does exist, display it!		
+		updateCurrentGistView(gameState.currentGist);
 	}
 
 	// Update UI
@@ -306,14 +308,13 @@ function handleTurnChange (disconnectedPlayerId) {
 			} else {				
 				editGist(gameState.currentGist.id, editor.getValue());
 				console.log("handleTurnChange: now editing gist " + gameState.currentGist.id);
-			}
+			}		
 		}
 	}
 
 	changeTurn();
-	
-	console.log("turn changed!");
-	console.log("turnIndex: " + gameState.turnIndex + ", # players: " + gameState.players.length, ", current player: " + getCurrentPlayer().id + "  -  " + getCurrentPlayer().login);
+		
+	console.log("TURN CHANGED! turnIndex: " + gameState.turnIndex + ", # players: " + gameState.players.length, ", current player: " + getCurrentPlayer().id + " - " + getCurrentPlayer().login);
 
 	// If user is no longer the current player, prevent them from typing/broadcasting!
 	if ( socket.id !== getCurrentPlayer().id ) {		
@@ -335,9 +336,12 @@ function handleTurnChange (disconnectedPlayerId) {
 
 // When receiving "newGist" event from server,
 function handleNewGist (gistData) {
-	// Update local state
 	console.log("called handleNewGist at " + new Date().toString().substring(16,25), 'color: green; font-weight: bold;');
 	console.log(gistData);
+
+	// Update local state
+	gameState.currentGist = gistData;
+
 	// Update views
 	updateCurrentGistView(gistData);
 }
@@ -508,13 +512,11 @@ function createNewGist() {
 
 		var gistObject = JSON.parse(responseText);
 
-		// Save new gist ID and URL locally
-		currentGist = {id: gistObject.id, url: gistObject.html_url, owner: gistObject.owner.login};
+		// Save new Gist data locally and update UI
+		handleNewGist({id: gistObject.id, url: gistObject.html_url, owner: gistObject.owner.login});
 
-		// Send new gist data to server
-		socket.emit('newGist', {id: gistObject.id, url: gistObject.html_url, owner: gistObject.owner.login});
-
-		updateCurrentGistView({id: gistObject.id, url: gistObject.html_url, owner: gistObject.owner.login});
+		// Send gist data to server
+		socket.emit('newGist', gameState.currentGist);
 
 	}, handleError);
 

--- a/public/local.js
+++ b/public/local.js
@@ -290,24 +290,24 @@ function handleTurnChange () {
 	// Remove highlight from previous player's name in playerListView
 	togglePlayerHighlight(false);
 
-	// Temporarily save the previous player ID for later comparison
-	var previousPlayerId = getCurrentPlayer().id;
+	// Temporarily save the previous player for later comparison
+	var previousPlayer = getCurrentPlayer();
 	
 	changeTurn();
 
-	// If user's turn is ending and a Gist exists, fork and/or edit the gist before passing control to next player!	
-	if (socket.id === previousPlayerId && gameState.currentGist != null) {
+	// If this client's turn is ending and a Gist exists, fork and/or edit the gist before passing control to next player!	
+	if (socket.id === previousPlayer.id && gameState.currentGist != null) {
 		console.log("User's turn is about to end.");
 
-		// If the current player does NOT own the current Gist,
-		if (getCurrentPlayer().login !== gameState.currentGist.owner) {
+		// If this client (the previous player) does NOT own the current Gist,
+		if (previousPlayer.login !== gameState.currentGist.owner) {
 			
 			console.log("handleTurnChange: now forking and editing gist " + gameState.currentGist.id);
 
-			// Fork/edit current Gist on behalf of player whose turn is about to end, and send new ID to server
+			// Fork/edit current Gist on behalf of this client (the previous player, whose turn is ending), and send new ID to server
 			forkAndEditGist(gameState.currentGist.id, editor.getValue());
 		
-		// Otherwise, JUST EDIT the current Gist and send new ID to server
+		// Otherwise, just edit the current Gist
 		} else {
 		
 			console.log("handleTurnChange: now editing gist " + gameState.currentGist.id);	

--- a/public/local.js
+++ b/public/local.js
@@ -325,7 +325,7 @@ function handleTurnChange () {
 	}
 
 	// Update UI
-	togglePlayerHighlight(true);
+	togglePlayerHighlight(getCurrentPlayer().id);
 	updateTimeLeftView(gameState.nextTurnTimestamp);
 	updateCurrentTurnView(getCurrentPlayer().login);
 	updateNextTurnView(getNextPlayer().login);
@@ -367,17 +367,19 @@ function toggleMyTurnHighlight () {
 
 }
 
-// Highlight name of current player in playerListView
-function togglePlayerHighlight (toggleOn) {
-	// First check if element exists, for case where user is the only player
-	if ( document.getElementById(getCurrentPlayer().id) ) {
-		// Add highlight
-		if (toggleOn) {
-			document.getElementById( getCurrentPlayer().id ).classList.add('highlight');
-		// Remove highlight
-		} else {
-			document.getElementById( getCurrentPlayer().id ).classList.remove('highlight');
-		}	
+// Highlight name of specified player in playerListView
+function togglePlayerHighlight (playerId) {	
+	var highlightedPlayerElement = document.querySelector('.highlight');
+	var nextPlayerElement = document.getElementById(playerId);
+	
+	// Remove highlight from the currently-highlighted element if it exists:
+	if (highlightedPlayerElement) {
+		highlightedPlayerElement.classList.remove('highlight');
+	}
+
+	// Add highlight to specified player element (if element exists)	
+	if (nextPlayerElement) {		
+		nextPlayerElement.classList.add('highlight');
 	}
 }
 

--- a/public/local.js
+++ b/public/local.js
@@ -283,6 +283,11 @@ function handleGameState (serverGameState) {
 	updateCurrentTurnView(getCurrentPlayer().login);
 	updateNextTurnView(getCurrentPlayer().login);
 	toggleMyTurnHighlight();
+
+	// If user is the current player, let them type!
+	if ( socket.id === getCurrentPlayerId() ) {
+		editor.setReadOnly(false);
+	}
 }
 
 // When receiving new player list data from server

--- a/public/local.js
+++ b/public/local.js
@@ -179,7 +179,7 @@ function loginUser (userData) {
 // Send editorInputView data to server
 function handleLocalEditorTextChange (event) {
 	// If user is the current player, they can broadcast
-	if (socket.id === getCurrentPlayerId() ) {
+	if (socket.id === getCurrentPlayer().id ) {
 		// Send data to server
 		socket.emit( 'editorTextChange', editor.getValue() );
 	}
@@ -197,7 +197,7 @@ function handleUserNameChange (event) {
 	//console.log('%c ' + myNameView.textContent, 'color: green; font-weight: bold;');
 	
 	// Update UI if user is the current or next player
-	if (getCurrentPlayerId() === socket.id) {
+	if (getCurrentPlayer().id === socket.id) {
 		updateCurrentTurnView(myNameView.textContent);	
 	} else if (nextPlayerId === socket.id) {
 		updateNextTurnView(myNameView.textContent);	
@@ -283,7 +283,7 @@ function handleGameState (serverGameState) {
 	toggleMyTurnHighlight();
 
 	// If user is the current player, let them type!
-	if ( socket.id === getCurrentPlayerId() ) {
+	if ( socket.id === getCurrentPlayer().id ) {
 		editor.setReadOnly(false);
 	}
 }
@@ -311,7 +311,7 @@ function handlePlayerJoined (playerData) {
 	//console.log(playerArray);
 
 	// Get names of current and next players based on saved local IDs
-	var currentPlayerName = playerData[getCurrentPlayerId()].login;
+	var currentPlayerName = playerData[getCurrentPlayer().id].login;
 	var nextPlayerName = playerData[nextPlayerId].login;
 
 	//console.log('Updating UI with currentPlayerName: ' + currentPlayerName + ', nextPlayerName: ' + nextPlayerName);
@@ -330,7 +330,7 @@ function handleTurnChange () {
 	togglePlayerHighlight(false);
 
 	// Temporarily save the previous player ID for later comparison
-	var previousPlayerId = getCurrentPlayerId();
+	var previousPlayerId = getCurrentPlayer().id;
 	
 	changeTurn();
 
@@ -356,7 +356,7 @@ function handleTurnChange () {
 	}
 	
 	// If user is no longer the current player, prevent them from typing/broadcasting!
-	if ( socket.id !== getCurrentPlayerId() ) {
+	if ( socket.id !== getCurrentPlayer().id ) {
 		console.log("User's turn is over.");
 		editor.setReadOnly(true);
 	// Otherwise if user's turn is now starting,
@@ -410,7 +410,7 @@ function updateLoggedInView (userName, userAvatar) {
 function toggleMyTurnHighlight () {	
 
 	// If user is the next player, highlight text box
-	if ( socket.id === getCurrentPlayerId() ) {
+	if ( socket.id === getCurrentPlayer().id ) {
 		document.body.classList.add('myturn');
 	} else {
 		document.body.classList.remove('myturn');
@@ -421,13 +421,13 @@ function toggleMyTurnHighlight () {
 // Highlight name of current player in playerListView
 function togglePlayerHighlight (toggleOn) {
 	// First check if element exists, for case where user is the only player
-	if ( document.getElementById(getCurrentPlayerId()) ) {
+	if ( document.getElementById(getCurrentPlayer().id) ) {
 		// Add highlight
 		if (toggleOn) {
-			document.getElementById( getCurrentPlayerId() ).classList.add('highlight');
+			document.getElementById( getCurrentPlayer().id ).classList.add('highlight');
 		// Remove highlight
 		} else {
-			document.getElementById( getCurrentPlayerId() ).classList.remove('highlight');
+			document.getElementById( getCurrentPlayer().id ).classList.remove('highlight');
 		}	
 	}
 }
@@ -753,10 +753,6 @@ function changeTurn() {
 
 function getCurrentPlayer() {
 	return gameState.players[gameState.turnIndex];
-}
-
-function getCurrentPlayerId() {
-	return gameState.players[gameState.turnIndex].id;
 }
 
 function getNextPlayer() {

--- a/public/local.js
+++ b/public/local.js
@@ -330,7 +330,7 @@ function handleTurnChange (turnData) {
 
 	// Update UI
 	togglePlayerHighlight(true);
-	updateTimeLeftView(turnData.millisRemaining);
+	updateTimeLeftView(turnData.timeRemaining);
 	updateCurrentTurnView(turnData.current.name);
 	updateNextTurnView(turnData.next.name);	
 	toggleMyTurnHighlight();
@@ -359,7 +359,7 @@ function handleUpdateState (turnData) {
 	togglePlayerHighlight(true);
 	
 	// Update UI
-	updateTimeLeftView(turnData.millisRemaining);
+	updateTimeLeftView(turnData.timeRemaining);
 	updateCurrentTurnView(turnData.current.name);
 	updateNextTurnView(turnData.next.name);	
 	toggleMyTurnHighlight();	

--- a/public/local.js
+++ b/public/local.js
@@ -144,7 +144,9 @@ editor.getSession().on('changeScrollTop', handleLocalEditorScrollChange);
 socket.on('editorTextChange', handleServerEditorTextChange);
 socket.on('editorCursorChange', handleServerEditorCursorChange);
 socket.on('editorScrollChange', handleServerEditorScrollChange);
+socket.on('gameState', handleGameState);
 socket.on('playerJoined', handlePlayerJoined);
+socket.on('playerLeft', handlePlayerLeft);
 socket.on('turnChange', handleTurnChange);
 socket.on('newGist', handleNewGist);
 

--- a/public/local.js
+++ b/public/local.js
@@ -108,7 +108,7 @@ playerJoined 		Server 		All other clients 	{id, login, avatar_url} 	handlePlayer
 gameState 			Server 		One client 			See game state model! 		handleGameState					Initialize game state for new player that just logged in,
 																													and trigger new gist creation if game is just starting!
 playerLeft 			Server 		All other clients 	id 															Update other clients to remove disconnected player
-turnChange 			Server 		All clients 		null ??? 					handleTurnChange				Triggerclients to change the turn
+turnChange 			Server 		All clients 		onDisconnect (Boolean)		handleTurnChange				Trigger clients to change the turn
 newGist 			Client 		Server 				{id, url, owner} 			handleNewGist					Broadcast new Gist data
 editorTextChange	Client 		Server 				"just a string!" 			handleLocalEditorTextChange		Broadcast changes to code editor content
 editorScrollChange 	Client 		Server 				{scrollLeft, scrollTop} 	handleLocalEditorScrollChange	Broadcast changes to code editor content
@@ -283,14 +283,14 @@ function handlePlayerLeft (playerId) {
 }
 
 // When receiving turnChange event from server
-function handleTurnChange (disconnectedPlayerId) {
+function handleTurnChange (onDisconnect) {
 	console.log('%c turnChange event received! TIME: ' + new Date().toString().substring(16,25), 'color: blue; font-weight: bold;');
 
 	// Update the timestamp of the next turn, reset the clock!
 	gameState.nextTurnTimestamp = Date.now() + turnDuration;
 
 	// If turn change was NOT triggered by current player disconnecting, and a Gist exists,
-	if (!disconnectedPlayerId && gameState.currentGist != null) {
+	if (!onDisconnect && gameState.currentGist != null) {
 		
 		// Temporarily save previous player info before changing turn
 		var previousPlayer = getCurrentPlayer();

--- a/public/local.js
+++ b/public/local.js
@@ -241,8 +241,8 @@ function handleGameState (serverGameState) {
 	}
 
 	// If no Gist exists, create it!
-	if (gameState.currentGist !== null)  {
-		handleCreateNewGist();
+	if (gameState.currentGist == null)  {
+		createNewGist();
 	}
 
 	// Update UI
@@ -252,7 +252,7 @@ function handleGameState (serverGameState) {
 	updateNextTurnView(getNextPlayer().login);
 	toggleMyTurnHighlight();
 
-	// If user is the current player, let them type!
+	// If this client is the current player, let them type!
 	if ( socket.id === getCurrentPlayer().id ) {
 		editor.setReadOnly(false);
 	}
@@ -487,8 +487,8 @@ function updateCurrentGistView (gistData) {
 	GITHUB API FUNCTIONS
 ---------------------------------------------------- */
 // Make a POST request via AJAX to create a Gist for the current user
-function handleCreateNewGist() {
-	console.log('called handleCreateNewGist at ' + new Date().toString().substring(16,25), 'color: red; font-weight: bold;');
+function createNewGist() {
+	console.log('called createNewGist at ' + new Date().toString().substring(16,25), 'color: red; font-weight: bold;');
 	// use currentAccessToken	
 	// use https://developer.github.com/v3/gists/#create-a-gist
 
@@ -504,12 +504,10 @@ function handleCreateNewGist() {
 
 	postWithGitHubToken('https://api.github.com/gists', gistObject).then(function(responseText){
 		//console.log(responseText);
-		console.log('handleCreateNewGist: response received at ' + new Date().toString().substring(16,25), 'color: red; font-weight: bold;');		
+		console.log('createNewGist: response received at ' + new Date().toString().substring(16,25), 'color: red; font-weight: bold;');		
 
 		var gistObject = JSON.parse(responseText);
 
-		console.dir(gistObject);
-		
 		// Save new gist ID and URL locally
 		currentGist = {id: gistObject.id, url: gistObject.html_url, owner: gistObject.owner.login};
 

--- a/public/local.js
+++ b/public/local.js
@@ -53,8 +53,6 @@ var timeLeftView = document.getElementById('timeleft');
 var currentTurnView = document.getElementById('currentturn');
 var nextTurnView = document.getElementById('nextturn');
 var playerListView = document.getElementById('playerlist');
-var myNameView = document.getElementById('myname');
-var myNameListItemView = document.getElementById('me');
 var currentGistView = document.getElementById('currentgist');
 /* -------------------------------------------------
 	GITHUB AUTHENTICATION	
@@ -149,15 +147,6 @@ socket.on('playerJoined', handlePlayerJoined);
 socket.on('playerLeft', handlePlayerLeft);
 socket.on('turnChange', handleTurnChange);
 socket.on('newGist', handleNewGist);
-
-// When client connects to server,
-socket.on('connect', function(){	
-	// Generate default name to match socket.id
-	//myNameView.textContent = 'Anonymous-' + socket.id.slice(0,4);
-	
-	// Update ID of first <li> in playerListView for player name highlighting with togglePlayerHighlight()
-	myNameListItemView.id = socket.id;
-});
 
 // When client disconnects, stop the timer!
 socket.on('disconnect', function(){	
@@ -362,15 +351,6 @@ function updateLoggedInView (userName, userAvatar) {
 	window.setTimeout(function(){
 		loginModalView.style.display = 'none';
 	}, 900);
-
-	// Set myNameView to use GitHub username
-	myNameView.textContent = userName;
-
-	// Display user's GitHub avatar image
-	var userAvatarElem = document.createElement('img');
-  	userAvatarElem.src = userAvatar;
-  	userAvatarElem.classList.add('avatar');
-  	myNameListItemView.insertBefore(userAvatarElem, myNameView);
 }
 
 // UI highlights to notify user when it's their turn
@@ -402,7 +382,7 @@ function togglePlayerHighlight (toggleOn) {
 // Update list of players
 function updatePlayerListView (playerArray) {
 
-	// First reorder the player array so current user is at the top (but removed from this list), without modifying the turn order
+	// First reorder the player array so current user is at the top, without modifying the turn order
 	var clientIndex = getPlayerIndexById(socket.id, playerArray);
 	var playersTopSegment = playerArray.slice(clientIndex);
 	var playersBottomSegment = playerArray.slice(0, clientIndex);
@@ -412,9 +392,6 @@ function updatePlayerListView (playerArray) {
 	while (playerListView.firstChild) {
     	playerListView.removeChild(playerListView.firstChild);
 	}
-
-	// Put li#me back into playerListView! (using previously saved reference)
-	playerListView.appendChild(myNameListItemView);
 
 	// Append player names to playerListView
 	reorderedPlayers.forEach(function(player){		

--- a/public/local.js
+++ b/public/local.js
@@ -81,7 +81,7 @@ var editor = ace.edit('editor');
 var Range = ace.require('ace/range').Range;
 editor.setTheme("ace/theme/monokai");
 editor.getSession().setMode('ace/mode/javascript');
-
+editor.setReadOnly(true);
 
 /* ------------------------------------------------------------
 	EVENT LISTENERS	/ SEND DATA TO SERVER

--- a/server.js
+++ b/server.js
@@ -240,7 +240,7 @@ io.on('connection', function (socket) {
 	socket.on('newGist', function (data) {
 		
 		// Double check that this user is allowed to broadcast a new gist!
-		if (socket.id === getPreviousPlayer().id ) {
+		if (socket.id === getPreviousPlayer().id) {
 			console.log('\nnewGist event received!\n');
 			//console.log(data);
 

--- a/server.js
+++ b/server.js
@@ -132,12 +132,12 @@ io.on('connection', function (socket) {
 	console.log('\nA user connected! (But not yet logged in.)\n');		
 
 	// When a player logs in,
-	socket.on('playerJoined', function (userData) {
+	socket.on('playerJoined', function (playerData) {
 		console.log('\n* * * * # # # #  User logged in!  # # # # * * * * *');
-		console.log('\t\t > > > ' + userData.login + ' < < <\n');		
+		console.log('\t\t > > > ' + playerData.login + ' < < <\n');		
 
 		// Add new player
-		gameState.players.push({id: socket.id, login: userData.login, avatar_url: userData.avatar_url});
+		gameState.players.push({id: socket.id, login: playerData.login, avatar_url: playerData.avatar_url});
 		
 		// If there is 1 player logged in, START THE GAME!!!
 		if (gameState.players.length === 1) {
@@ -148,7 +148,7 @@ io.on('connection', function (socket) {
 		socket.emit('gameState', gameState);
 
 		// Broadcast new player data to all OTHER clients
-		socket.broadcast.emit('playerJoined', playerData);
+		socket.broadcast.emit('playerJoined', {id: socket.id, login: playerData.login, avatar_url: playerData.avatar_url});
 
 	});
 

--- a/server.js
+++ b/server.js
@@ -110,7 +110,7 @@ playerJoined 		Server 		All other clients 	{id, login, avatar_url} 	Update other
 gameState 			Server 		One client 			See game state model! 		Initialize game state for new player that just logged in,
 																					and trigger new gist creation if game is just starting!
 playerLeft 			Server 		All other clients 	id 							Update other clients to remove disconnected player
-turnChange 			Server 		All clients 		null ??? 					Trigger clients to change the turn
+turnChange 			Server 		All clients 		onDisconnect (Boolean)		Trigger clients to change the turn
 newGist 			Client 		Server 				{id, url, owner} 			Broadcast new Gist data
 editorTextChange	Client 		Server 				"just a string!" 			Broadcast changes to code editor content
 editorScrollChange 	Client 		Server 				{scrollLeft, scrollTop} 	Broadcast changes to code editor content
@@ -192,8 +192,8 @@ io.on('connection', function (socket) {
 					// Restart the timer
 					timerId = startTurnTimer(timerId, turnDuration);
 
-					// Change the turn, including ID of disconnected player to send to clients
-					changeTurn(socket.id);
+					// Change the turn, including the onDisconnect=true flag to signal clients NOT to fork/edit the Gist on this turn change
+					changeTurn(true);
 			}
 
 		} else {
@@ -261,11 +261,11 @@ io.on('connection', function (socket) {
 /* -------------------------------------------------
 	FUNCTIONS
 ---------------------------------------------------- */
-function changeTurn(disconnectedPlayerId) {
+function changeTurn(onDisconnect) {
 	gameState.turnIndex = (gameState.turnIndex + 1) % gameState.players.length;
 	
 	// Broadcast turnChange to ALL clients, with disconnected player ID (which exists only if current player disconnected):
-	io.emit('turnChange', disconnectedPlayerId);
+	io.emit('turnChange', onDisconnect);
 }
 
 // Initializes the turn and turn timer, returns timerId

--- a/server.js
+++ b/server.js
@@ -210,7 +210,7 @@ io.on('connection', function (socket) {
 		//console.log(data);
 
 		// Double check that this user is allowed to type (in case of client-side tampering with the JS!)
-		if ( socket.id === getCurrentPlayerId() ) {			
+		if ( socket.id === getCurrentPlayer().id ) {			
 			// Update saved state of the shared text editor
 			gameState.editor.content = data;
 
@@ -229,7 +229,7 @@ io.on('connection', function (socket) {
 		//console.log(data);
 
 		// Double check that this user is allowed to broadcast (in case of client-side tampering with the JS!)
-		if (socket.id === getCurrentPlayerId() ) {			
+		if (socket.id === getCurrentPlayer().id ) {			
 			// Update saved state of the shared text editor
 			gameState.editor.cursorAndSelection = data;
 
@@ -248,7 +248,7 @@ io.on('connection', function (socket) {
 		//console.log(data);
 
 		// Double check that this user is allowed to broadcast (in case of client-side tampering with the JS!)
-		if (socket.id === getCurrentPlayerId() ) {			
+		if (socket.id === getCurrentPlayer().id ) {			
 			// Update saved state of the shared text editor
 			gameState.editor.scroll = data;
 
@@ -309,8 +309,8 @@ function startTurnTimer(timerId, turnDuration) {
 }
 
 // Helper functions, just in case:
-function getCurrentPlayerId() {
-	return gameState.players[gameState.turnIndex].id;
+function getCurrentPlayer() {
+	return gameState.players[gameState.turnIndex];
 }
 function getPlayerById(id, playerList){
 	for (var i = 0; i < playerList.length; i++) {

--- a/server.js
+++ b/server.js
@@ -205,72 +205,56 @@ io.on('connection', function (socket) {
 
 	// When "editorTextChange" event received, update editor state and broadcast it back out
 	socket.on('editorTextChange', function (data) {
-		
-		//console.log('editorTextChange event received!');
-		//console.log(data);
 
 		// Double check that this user is allowed to type (in case of client-side tampering with the JS!)
-		if ( socket.id === getCurrentPlayer().id ) {			
+		if ( socket.id === getCurrentPlayer().id ) {
 			// Update saved state of the shared text editor
 			gameState.editor.content = data;
 
 			// Broadcast updated editor content to other clients
 			socket.broadcast.emit('editorTextChange', gameState.editor.content);
-
-			//console.log('Broadcasting gameState.editor.content to other clients!');
 		}
-		
 	});
 
 	// When "editorCursorChange" event received, update editor state and broadcast it back out
 	socket.on('editorCursorChange', function (data) {
-		
-		//console.log('editorCursorChange event received!');
-		//console.log(data);
 
 		// Double check that this user is allowed to broadcast (in case of client-side tampering with the JS!)
-		if (socket.id === getCurrentPlayer().id ) {			
+		if (socket.id === getCurrentPlayer().id ) {
 			// Update saved state of the shared text editor
 			gameState.editor.cursorAndSelection = data;
 
 			// Broadcast data to other clients
 			socket.broadcast.emit('editorCursorChange', gameState.editor.cursorAndSelection);
-
-			//console.log('Broadcasting editorCursorChange to other clients!');
 		}
-		
 	});
 
 	// When "editorScrollChange" event received, update editor state and broadcast it back out
 	socket.on('editorScrollChange', function (data) {
 		
-		//console.log('editorScrollChange event received!');
-		//console.log(data);
-
 		// Double check that this user is allowed to broadcast (in case of client-side tampering with the JS!)
-		if (socket.id === getCurrentPlayer().id ) {			
+		if (socket.id === getCurrentPlayer().id ) {
 			// Update saved state of the shared text editor
 			gameState.editor.scroll = data;
 
 			// Broadcast data to other clients
 			socket.broadcast.emit('editorScrollChange', gameState.editor.cursorAndSelection);
-
-			//console.log('Broadcasting editorScrollChange to other clients!');
-		}
-		
+		}	
 	});
 
 	// When "newGist" event received, update state and broadcast it back out
 	socket.on('newGist', function (data) {
 		
-		console.log('\nnewGist event received!\n');
-		//console.log(data);
+		// Double check that this user is allowed to broadcast a new gist!
+		if (socket.id === getPreviousPlayer().id ) {
+			console.log('\nnewGist event received!\n');
+			//console.log(data);
 
-		gameState.currentGist = data;
+			gameState.currentGist = data;
 
-		// Broadcast data to other clients
-		socket.broadcast.emit('newGist', data);
-		
+			// Broadcast data to other clients
+			socket.broadcast.emit('newGist', data);
+		}
 	});
 
 });	// End of SocketIO part of the code
@@ -312,6 +296,12 @@ function startTurnTimer(timerId, turnDuration) {
 function getCurrentPlayer() {
 	return gameState.players[gameState.turnIndex];
 }
+
+function getPreviousPlayer() {
+	var previousPlayerIndex = (gameState.turnIndex - 1) % gameState.players.length;
+	return gameState.players[previousPlayerIndex];
+}
+
 function getPlayerById(id, playerList){
 	for (var i = 0; i < playerList.length; i++) {
 		if (playerList[i].id === id) {

--- a/server.js
+++ b/server.js
@@ -68,7 +68,7 @@ server.listen(port, function() {
 	GAME STATE:
 
 {
-  timeRemaining,
+  nextTurnTimestamp,
   turnIndex,
   currentGist: {id, url, owner},
   playerList:
@@ -86,7 +86,7 @@ server.listen(port, function() {
 -------------------------------------------------------------- */
 
 let gameState = {
-	timeRemaining: null,
+	nextTurnTimestamp: null,
 	turnIndex: 0,
 	currentGist: null,
 	players: [],
@@ -268,16 +268,16 @@ function startTurnTimer(timerId, turnDuration) {
 	console.log('\nInitializing turn timer!');
 
 	// Initialize or reset time remaining
-	gameState.timeRemaining = turnDuration;
+	gameState.nextTurnTimestamp = Date.now() + turnDuration;
 
-	console.log( 'Next turn at: ' + new Date(Date.now() + gameState.timeRemaining).toString().substring(16,25) );
+	console.log( 'Next turn at: ' + new Date(gameState.nextTurnTimestamp).toString().substring(16,25) );
 
-	// Every time the timer goes off,
+	// Every time the timer goes off, update timestamp and change turn!
 	timerId = setInterval(() => {
 		console.log('\n >>>>>>>>>>>  ' + new Date().toString().substring(16,25)	+ ' - Time to change turns!  <<<<<<<<<<\n');
 
 		// Update time of next turn change
-		gameState.timeRemaining = turnDuration;
+		gameState.nextTurnTimestamp = Date.now() + turnDuration;
 
 		changeTurn();
 

--- a/server.js
+++ b/server.js
@@ -98,12 +98,6 @@ let gameState = {
     }
 };
 
-/* ------------------------------------------------------------
-	EVENT NAMES:
-
-	// Will redo this part!
-
--------------------------------------------------------------- */
 const turnDuration = 60000;
 let timerId = null;
 
@@ -138,7 +132,7 @@ io.on('connection', function (socket) {
 	console.log('\nA user connected! (But not yet logged in.)\n');		
 
 	// When a user logs in,
-	socket.on('userLogin', function (userData) {
+	socket.on('playerJoined', function (userData) {
 		console.log('\n* * * * # # # #  User logged in!  # # # # * * * * *');
 		console.log('\t\t > > > ' + userData.login + ' < < <\n');		
 
@@ -154,7 +148,7 @@ io.on('connection', function (socket) {
 			socket.emit('editorCursorChange', gameState.editor.cursorAndSelection);
 		}
 		
-		// If there is 1 player logged in (the first player to join, who just triggered the "userLogin" event),
+		// If there is 1 player logged in (the first player to join, who just triggered the "playerJoined" event),
 		// START THE GAME!!!
 		if (gameState.players.length === 1) {
 			timerId = startTurnTimer(timerId, turnDuration, socket.id);
@@ -167,9 +161,9 @@ io.on('connection', function (socket) {
 		io.emit( 'updateState', getTurnData() );
 
 		// Broadcast updated playerList to ALL clients
-		io.emit('playerListChange', playerData);
+		io.emit('playerJoined', playerData);
 
-		console.log('\non("userLogin") -- turnData broadcasted!\n');		
+		console.log('\non("playerJoined") -- turnData broadcasted!\n');		
 	});
 
 	// When a user disconnects,
@@ -215,7 +209,7 @@ io.on('connection', function (socket) {
 				socket.broadcast.emit( 'updateState', getTurnData() );
 
 				// Broadcast updated playerList to update all other clients
-				socket.broadcast.emit('playerListChange', playerData);
+				socket.broadcast.emit('playerJoined', playerData);
 			}
 
 		} else {
@@ -280,16 +274,16 @@ io.on('connection', function (socket) {
 		
 	});
 
-	// When "newGistLink" event received, update state and broadcast it back out
-	socket.on('newGistLink', function (data) {
+	// When "newGist" event received, update state and broadcast it back out
+	socket.on('newGist', function (data) {
 		
-		console.log('\nnewGistLink event received!\n');
+		console.log('\nnewGist event received!\n');
 		//console.log(data);
 
 		gameState.currentGist = data;
 
 		// Broadcast data to other clients
-		socket.broadcast.emit('newGistLink', data);
+		socket.broadcast.emit('newGist', data);
 		
 	});
 

--- a/server.js
+++ b/server.js
@@ -188,8 +188,8 @@ io.on('connection', function (socket) {
 					// Restart the timer
 					timerId = startTurnTimer(timerId, turnDuration);
 
-					// Change the turn, passing control to the next player and broadcasting to all players
-					changeTurn();
+					// Change the turn, including ID of disconnected player to send to clients
+					changeTurn(socket.id);
 			}
 
 		} else {
@@ -257,10 +257,11 @@ io.on('connection', function (socket) {
 /* -------------------------------------------------
 	FUNCTIONS
 ---------------------------------------------------- */
-function changeTurn() {
+function changeTurn(disconnectedPlayerId) {
 	gameState.turnIndex = (gameState.turnIndex + 1) % gameState.players.length;
-	// Broadcast turnChange to ALL clients
-	io.emit('turnChange', null);
+	
+	// Broadcast turnChange to ALL clients, with disconnected player ID (which exists only if current player disconnected):
+	io.emit('turnChange', disconnectedPlayerId);
 }
 
 // Initializes the turn and turn timer, returns timerId

--- a/server.js
+++ b/server.js
@@ -131,39 +131,25 @@ io.on('connection', function (socket) {
 	
 	console.log('\nA user connected! (But not yet logged in.)\n');		
 
-	// When a user logs in,
+	// When a player logs in,
 	socket.on('playerJoined', function (userData) {
 		console.log('\n* * * * # # # #  User logged in!  # # # # * * * * *');
 		console.log('\t\t > > > ' + userData.login + ' < < <\n');		
 
-		// Add new user
+		// Add new player
 		gameState.players.push({id: socket.id, login: userData.login, avatar_url: userData.avatar_url});
-
-		// Send current state of the text editor to the new client, to initialize!
-		socket.emit('editorTextChange', gameState.editor.content);
-		if (gameState.editor.cursorAndSelection != null) {
-			socket.emit('editorScrollChange', gameState.editor.cursorAndSelection);
-		}
-		if (gameState.editor.cursorAndSelection != null) {
-			socket.emit('editorCursorChange', gameState.editor.cursorAndSelection);
-		}
 		
-		// If there is 1 player logged in (the first player to join, who just triggered the "playerJoined" event),
-		// START THE GAME!!!
+		// If there is 1 player logged in, START THE GAME!!!
 		if (gameState.players.length === 1) {
 			timerId = startTurnTimer(timerId, turnDuration, socket.id);
-			
-			// Notify the first user to create a new gist now!
-			socket.emit('createNewGist', null);
 		}
-			
-		// Broadcast current turn data to all clients (for the case where nextPlayerId changes when a second user joins)
-		io.emit( 'updateState', getTurnData() );
 
-		// Broadcast updated playerList to ALL clients
-		io.emit('playerJoined', playerData);
+		// Initialize new player
+		socket.emit('gameState', gameState);
 
-		console.log('\non("playerJoined") -- turnData broadcasted!\n');		
+		// Broadcast new player data to all OTHER clients
+		socket.broadcast.emit('playerJoined', playerData);
+
 	});
 
 	// When a user disconnects,

--- a/server.js
+++ b/server.js
@@ -293,7 +293,7 @@ function getCurrentPlayer() {
 }
 
 function getPreviousPlayer() {
-	var previousPlayerIndex = (gameState.turnIndex - 1) % gameState.players.length;
+	var previousPlayerIndex = (gameState.turnIndex + gameState.players.length - 1) % gameState.players.length;
 	return gameState.players[previousPlayerIndex];
 }
 

--- a/server.js
+++ b/server.js
@@ -66,12 +66,11 @@ server.listen(port, function() {
 
 /* ------------------------------------------------------------
 	GAME STATE:
-
 {
   nextTurnTimestamp,
   turnIndex,
   currentGist: {id, url, owner},
-  playerList:
+  players:
     [
       {id, login,avatar_url}, { ... }, { ... }, ...
     ],
@@ -167,6 +166,11 @@ io.on('connection', function (socket) {
 
 			// Temporarily save ID of current player (before removing from player list, for a later check!)
 			var currentPlayerId = getCurrentPlayer().id;
+
+			// Update turnIndex only if disconnected player comes BEFORE current player in the players array, and there are still players in the game:
+			if ( getPlayerIndexById(socket.id, gameState.players) < gameState.turnIndex && gameState.players.length > 1) {
+				gameState.turnIndex--;
+			}
 
 			// Remove disconnected player from player list
 			removePlayer(socket.id, gameState.players);


### PR DESCRIPTION
Closes #16, also closes #18 and #14.

**Summary of changes:**

- Set editor to default to read-only mode, allow editing only once current player has been initialized

- Refactor state, use `gameState` object on both server and clients

- Refactor events, game initialization, and some UI functions too, stripping out and rebuilding all the guts of this app!

- Add and rename/refactor these key client functions: `handleGameState`, `handlePlayerJoined`, and `handlePlayerLeft`

- Add helper functions to both server and clients for easily accessing player data

- Use timestamps on both server and client for the turn timer

- Send flag with `turnChange` event to signal clients *not* to fork/edit Gist if turn change was triggered by the current player disconnecting

- Update `turnIndex` when players disconnect (if needed), so index always points to the correct current player (very important bug fix!)